### PR TITLE
Command chaining

### DIFF
--- a/commands/converse.py
+++ b/commands/converse.py
@@ -67,11 +67,17 @@ class converse:
         match = re.search(r"(?:^|\s)/?r/(\S*)", message, re.IGNORECASE)
         if match:
             msg.reply("https://www.reddit.com/r/{}".format(match.group(1)))
+            return
         # custom section
         if (msg.sender == "Jazstar" and
             "slime" in msg.message and
             "XilasCrowe" in DB.get_channel_members(msg.channel)):
             msg.reply("Oy xilas I heard you like slime!")
+            return
+
+        # after all attempts, must indicate failure if pinged
+        if cmd.pinged:
+            return 1
 
 def strip(string):
     """Strips all non-alphanumeric characters."""

--- a/helpers/parse.py
+++ b/helpers/parse.py
@@ -5,26 +5,25 @@ Provides functions for parsing and formatting stuff into other stuff.
 
 import re
 import shlex
-import pyaib.util.data as data
+from copy import copy
 from helpers.config import CONFIG
 
 def parseprint(message):
     #print("[\x1b[1;32mParser\x1b[0m] " + str(message))
     pass
 
-class ParsedCommand():
-    """ParsedCommand
+def parse_commands(irc_c, message):
+    """Takes a message object and returns a list of parsed commands."""
+    submessages = [m.trim() for m in message.message.split("&&")]
+    messages = []
+    for submessage in submessages:
+        msg = copy(message)
+        msg.message = submessage
+        messages.append(msg)
+    return [ParsedCommand(irc_c, m) for m in messages]
 
-    A dictionary with pings, commands and arguments bundled up nicely.
-    .raw - the original message, unchanged
-    .ping - nick of the message's ping
-    .pinged - bool; was TARS pinged?
-    .command - the actual command itself
-        .command - the root command
-        .arguments - dict with each keys of tags and values as argument
-                     tuples. First tuple has tag "root". Tags will be
-                     either long or short depending on user input.
-    """
+class ParsedCommand():
+    """Object representing a single command"""
     def __init__(self, irc_c, message):
         # Check that the message is a string
         self.sender = message.sender

--- a/helpers/parse.py
+++ b/helpers/parse.py
@@ -5,8 +5,10 @@ Provides functions for parsing and formatting stuff into other stuff.
 
 import re
 import shlex
-from copy import copy
+from copy import deepcopy
 from helpers.config import CONFIG
+
+from pprint import pprint
 
 def parseprint(message):
     #print("[\x1b[1;32mParser\x1b[0m] " + str(message))
@@ -14,21 +16,16 @@ def parseprint(message):
 
 def parse_commands(irc_c, message):
     """Takes a message object and returns a list of parsed commands."""
-    submessages = [m.trim() for m in message.message.split("&&")]
-    messages = []
-    for submessage in submessages:
-        msg = copy(message)
-        msg.message = submessage
-        messages.append(msg)
-    return [ParsedCommand(irc_c, m) for m in messages]
+    submessages = [m.strip() for m in message.message.split("&&")]
+    return [ParsedCommand(irc_c, message, m) for m in submessages]
 
 class ParsedCommand():
     """Object representing a single command"""
-    def __init__(self, irc_c, message):
+    def __init__(self, irc_c, msg, message_text):
         # Check that the message is a string
-        self.sender = message.sender
-        self.channel = message.channel
-        message = message.message
+        self.sender = msg.sender
+        self.channel = msg.channel
+        message = message_text
         self.raw = str(message)
         self.ping = None # identity of the ping
         self.unping = None # raw command without ping

--- a/plugins/parsemessages.py
+++ b/plugins/parsemessages.py
@@ -3,21 +3,18 @@
 Plugin that parses messages into commands and then does stuff
 """
 
-from helpers import parse
 import commands
-from pyaib.plugins import observe, plugin_class
-import sys
-import inspect
-from helpers.error import CommandError, CommandNotExistError, MyFaultError
 from importlib import reload
-from pprint import pprint
-import time
+from pyaib.plugins import observe, plugin_class
+from helpers import parse
+from helpers.error import CommandError, CommandNotExistError, MyFaultError
 
-def try_command(attempt, irc_c, msg, cmd):
+def try_command(command_name, irc_c, msg, cmd):
+    """Execute the command of the given name."""
     try:
         # Call the command from the right file in commands/
         # getattr instead of commands[cmd] bc module subscriptability
-        command_class = getattr(commands.COMMANDS, attempt)
+        command_class = getattr(commands.COMMANDS, command_name)
         command_class.command(irc_c, msg, cmd)
     except CommandNotExistError:
         if cmd.pinged:
@@ -26,19 +23,19 @@ def try_command(attempt, irc_c, msg, cmd):
         elif msg.channel is None:
             # should be only in pm
             msg.reply("That's not a command.")
-    except CommandError as e:
-        msg.reply("\x02Invalid command:\x0F {}".format(str(e)))
-    except MyFaultError as e:
-        msg.reply("\x02Sorry!\x0F {}".format(str(e)))
-    except Exception as e:
+    except CommandError as exc:
+        msg.reply("\x02Invalid command:\x0F {}".format(str(exc)))
+    except MyFaultError as exc:
+        msg.reply("\x02Sorry!\x0F {}".format(str(exc)))
+    except Exception as exc:
         if msg.channel != '#tars':
             msg.reply(("An unexpected error has occurred. "
                        "I've already reported it — you don't need to "
                        "do anything."))
         # need to log the error somewhere - why not #tars?
-        irc_c.PRIVMSG("#tars",("\x02Error report:\x0F {} "
-                               "issued `{}` → `{}`"
-                              .format(msg.sender,msg.message,e)))
+        irc_c.PRIVMSG("#tars", ("\x02Error report:\x0F {} "
+                                "issued `{}` → `{}`"
+                                .format(msg.sender, msg.message, exc)))
         raise
 
 @plugin_class('parsemessages')
@@ -50,6 +47,7 @@ class ParseMessages():
 # wipe em and remake em to .reload
     @observe("IRC_MSG_PRIVMSG")
     def handleMessage(self, irc_c, msg):
+        submessages = msg
         cmd = parse.ParsedCommand(irc_c, msg)
         # cmd is the parsed msg (used to be msg.parsed)
         if cmd.command:

--- a/plugins/parsemessages.py
+++ b/plugins/parsemessages.py
@@ -9,24 +9,30 @@ from pyaib.plugins import observe, plugin_class
 from helpers import parse
 from helpers.error import CommandError, CommandNotExistError, MyFaultError
 
-def try_command(command_name, irc_c, msg, cmd):
+def try_command(irc_c, msg, cmd, command_name=None):
     """Execute the command of the given name."""
+    if command_name is None:
+        command_name = cmd.command
     try:
         # Call the command from the right file in commands/
         # getattr instead of commands[cmd] bc module subscriptability
         command_class = getattr(commands.COMMANDS, command_name)
         command_class.command(irc_c, msg, cmd)
+        return 0
     except CommandNotExistError:
         if cmd.pinged:
             # there are .converse strings for pinged
-            try_command('converse', irc_c, msg, cmd)
+            return try_command('converse', irc_c, msg, cmd)
         elif msg.channel is None:
             # should be only in pm
-            msg.reply("That's not a command.")
+            msg.reply("I don't know what '{}' means.".format(command_name))
+            return 1
     except CommandError as exc:
         msg.reply("\x02Invalid command:\x0F {}".format(str(exc)))
+        return 1
     except MyFaultError as exc:
         msg.reply("\x02Sorry!\x0F {}".format(str(exc)))
+        return 1
     except Exception as exc:
         if msg.channel != '#tars':
             msg.reply(("An unexpected error has occurred. "
@@ -38,6 +44,34 @@ def try_command(command_name, irc_c, msg, cmd):
                                 .format(msg.sender, msg.message, exc)))
         raise
 
+def execute_commands(irc_c, msg, cmds, command_name=None):
+    """Executes a series of commands."""
+    for cmd in cmds:
+        # reload command takes highest priority
+        if cmd.command == "reload":
+            # special case for .reload - needs high priority
+            msg.reply("Reloading commands...")
+            try:
+                reload(commands)
+            except:
+                msg.reply("Reload failed.")
+                raise
+            else:
+                msg.reply("Reload successful.")
+            continue
+        # indiciate quotemark parse error
+        if cmd.quote_error:
+            msg.reply(("I wasn't able to correctly parse your quotemarks, "
+                       "so I have interpreted them literally."))
+        # assume converse if no command specified
+        if not cmd.command:
+            command_name = 'converse'
+        # do not catch error if this fails
+        command_failed = try_command(irc_c, msg, cmd, command_name)
+        # only progress to next command if previous passed
+        if command_failed:
+            break
+
 @plugin_class('parsemessages')
 class ParseMessages():
     def __init__(self, irc_c, config):
@@ -46,38 +80,9 @@ class ParseMessages():
 # TODO: if plugins are just object instances, then we should be able to
 # wipe em and remake em to .reload
     @observe("IRC_MSG_PRIVMSG")
-    def handleMessage(self, irc_c, msg):
-        submessages = msg
-        cmd = parse.ParsedCommand(irc_c, msg)
-        # cmd is the parsed msg (used to be msg.parsed)
-        if cmd.command:
-            # this is a command!
-            if cmd.command == "reload":
-                # special case for .reload - needs high priority
-                msg.reply("Reloading commands...")
-                try:
-                    reload(commands)
-                except:
-                    msg.reply("Reload failed.")
-                    raise
-                else:
-                    msg.reply("Reload successful.")
-                return
-            # notify of a shlex error, if present
-            if cmd.quote_error:
-                msg.reply(("I wasn't able to correctly parse your quotemarks, "
-                           "so I have interpreted them literally."))
-            try_command(cmd.command, irc_c, msg, cmd)
-        else:
-            # not a command, and not pinged
-            # Send the message over to .converse
-            try_command('converse', irc_c, msg, cmd)
-        if msg.channel is None:
-            # we're working in PMs
-            pass
-        else:
-            # we're in a channel
-            pass
+    def handle_message(self, irc_c, msg):
+        cmds = parse.parse_commands(irc_c, msg)
+        execute_commands(irc_c, msg, cmds)
 
     @observe('IRC_MSG_INVITE')
     def invited(self, irc_c, msg):


### PR DESCRIPTION
Enable having multiple commands in a single message.

They'd be split by &&, like Linux, and also like Linux the next one would not happen if the previous one failed. Failure should be indicated by throwing an error, but will probably actually be handled by returning 0 in the bit that handles those errors.

I'd also like to have the ability to pipe the results of one command to another, though currently I don't really see a use case, so why bother.

Closes #118.