### PR TITLE
Add a delay between API requests

### DIFF
--- a/commands/propagate.py
+++ b/commands/propagate.py
@@ -3,6 +3,8 @@
 For propagating the database with wiki data.
 """
 
+import gevent
+
 from helpers.api import SCPWiki
 from helpers.error import CommandError
 from helpers.parse import nickColor
@@ -66,6 +68,8 @@ class propagate:
                     # Don't want to track fragments
                     continue
                 DB.add_article(page, commit=False)
+            # Give the API a moment to rest
+            gevent.sleep(5)
         DB.commit()
 
     @classmethod


### PR DESCRIPTION
I did not add a delay between Crom API pagination requests, resulting in unnecessary spikes on SMLT's server. This PR sleeps the propagation greenlet for a few seconds between generator iterations.

This coincides with a reduction in propagation frequency in the external schedule.

Adding a 5 second delay to every page (100 articles) adds about 5 seconds to the lc query and about 6000 seconds to the full query. This is not a problem so long as it's run less often than that.

-----

When both the current schedules coincide, two propagations will still be performed: I should find a way to cancel one of them so there is only one scheduled. propagation running at a time.

I should also find ways to move away from frequent full-database propagation and towards making on-demand requests to Crom directly, e.g. for .lc. This should not add a noticeable delay and will save us both a lot of bandwidth.

If I lose my attachment to tracking ratings, I should be able to propagate just the titles of existing works much less frequently while sacrificing very little accuracy. I'd still be able to perform regex search and title golf.