### PR TITLE
Fix rebooting

### DIFF
--- a/tars/__main__.py
+++ b/tars/__main__.py
@@ -50,6 +50,19 @@ def get_args_from_command_line():
 
 
 if __name__ == "__main__":
+    # When rebooting, we are being executed as script rather than as module
+    try:
+        import tars
+
+        print("Bot starting")
+    except ImportError:
+        print("Bot rebooting")
+        # Add dir to path to simulate being a module
+        import os
+        import sys
+
+        path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+        sys.path.insert(0, path)
     args = get_args_from_command_line()
     if args.docs:
         from tars.documentation.build import build


### PR DESCRIPTION
#228 reorganised the file structure from a bunch of scripts into a package, which changed the invocation method. This caused #237 where `os.execl` is invoking the process as a Python script instead of as a Python module.

This PR will resolve that. Merges into #234. Fixes #237.

I've been recommended to use an external process supervisor to restart the script from the outside when it is rebooted. I'm not sure how I'm going to detect that. I'm thinking I could probably throw an error and catch it right at the top, in `tars/__main__`? I really don't want to have to create an external script for this - the current invocation is too nice.

