### PR TITLE
Make the documentation site work on mobile

### DIFF
--- a/tars/documentation/src/Sidebar.svelte
+++ b/tars/documentation/src/Sidebar.svelte
@@ -76,10 +76,24 @@
       })
     }
   }
+
+  let sidebarOpen = false
+
+  function toggleSidebar () {
+    sidebarOpen = !sidebarOpen
+  }
 </script>
 
-<aside class="sticky h-screen top-0 bottom-0 flex flex-col
-              bg-primary-dark md:w-72 lg:w-96">
+<div on:click={toggleSidebar}
+     class="fixed inset-0 bg-black lg:hidden transition-opacity
+            {sidebarOpen ? "opacity-50" : "opacity-0 pointer-events-none"}">
+</div>
+
+<aside class="fixed h-screen top-0 bottom-0 left-0 transform
+              {sidebarOpen ? "" : "-translate-x-full"} transition-transform
+              lg:sticky lg:transform-none
+              flex flex-col
+              bg-primary-dark lg:w-96">
   <h1 class="text-7xl my-6 text-center font-bold text-primary-light">
     TARS
   </h1>
@@ -91,3 +105,9 @@
   </nav>
 </aside>
 
+<button on:click={toggleSidebar}
+        class="rounded-full w-20 h-20 bg-primary-dark
+               focus:outline-none focus:ring focus:ring-primary
+               fixed bottom-8 right-8 lg:hidden">
+  =
+</button>

--- a/tars/documentation/src/style.css
+++ b/tars/documentation/src/style.css
@@ -78,6 +78,7 @@ h4 {
 /* Spacing between the sections */
 section[data-role=section] {
   @apply my-24;
+  @apply mx-8;
 }
 section[data-role=command] {
   @apply my-16;


### PR DESCRIPTION
Merges into #120.

- [x] Hide the sidebar on mobile
- [x] Add a sidebar button for mobile
- [x] Make the sidebar button open/close the sidebar on mobile
- [x] ~~Disable IntersectionObserver stuff on mobile~~ Doesn't seem necessary
- [x] Make the document padding be good at low width